### PR TITLE
experiment(MediaType): Validate MediaType for Image Spec

### DIFF
--- a/opencontainers/image/v1/__init__.py
+++ b/opencontainers/image/v1/__init__.py
@@ -53,3 +53,14 @@ from .mediatype import (
     MediaTypeImageLayerNonDistributableZstd,
     MediaTypeImageConfig
 )
+
+DEFAULT_CONFIG_MEDIATYPE = MediaTypeImageConfig
+KNOWN_CONFIG_MEDIATYPE = (MediaTypeImageConfig)
+DEFAULT_IMAGELAYER_MEDIATYPE = MediaTypeImageLayer
+KNOWN_IMAGELAYER_MEDIATYPE = (MediaTypeImageLayer,
+    MediaTypeImageLayerGzip,
+    MediaTypeImageLayerZstd,
+    MediaTypeImageLayerNonDistributable,
+    MediaTypeImageLayerNonDistributableGzip,
+    MediaTypeImageLayerNonDistributableZstd
+    )

--- a/opencontainers/image/v1/manifest.py
+++ b/opencontainers/image/v1/manifest.py
@@ -4,11 +4,17 @@
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from typing import List,Tuple
+from ...logger import bot
 from opencontainers.struct import Struct
 from opencontainers.image.specs import Versioned
 from .descriptor import Descriptor
-
+from . import (
+    DEFAULT_CONFIG_MEDIATYPE,
+    DEFAULT_IMAGELAYER_MEDIATYPE,
+    KNOWN_CONFIG_MEDIATYPE,
+    KNOWN_IMAGELAYER_MEDIATYPE
+)
 
 class Manifest(Struct):
     '''Manifest provides `application/vnd.oci.image.manifest.v1+json` 
@@ -33,3 +39,43 @@ class Manifest(Struct):
         self.add("Layers", layers)
         self.add("Annotations", annotations)
         self.add("specs.Versioned", Versioned(schemaVersion))
+
+    @staticmethod
+    def verifyConfigMediaType(config: Descriptor,
+        default: str = DEFAULT_CONFIG_MEDIATYPE,
+        known_mediatypes: Tuple[str] = KNOWN_CONFIG_MEDIATYPE) -> bool:
+
+        if not config.MediaType.value:
+            config.MediaType.set(default)
+            return True
+        if config.MediaType.value in known_mediatypes:
+            return True
+        bot.error("{} is not a valid Config MediaType for this artifact.".format(config.MediaType.value))
+        return False
+
+    @staticmethod
+    def verifyImageLayerMediaType(layers: List[Descriptor],
+        default: str = DEFAULT_IMAGELAYER_MEDIATYPE,
+        known_mediatypes: Tuple[str] = KNOWN_IMAGELAYER_MEDIATYPE
+        ):
+
+        if len(layers) == 0:
+            return True
+
+        for layer in layers:
+            if not layer.MediaType.value:
+                layer.MediaType.set(default)
+                continue
+            if layer.MediaType.value in known_mediatypes:
+                continue
+            bot.error("{} is not a valid ImageLayer MediaType for this artifact.".format(layer.MediaType.value))
+            return False
+        # At this point all layers are valid
+        return True
+
+    def validate(self) -> bool:
+        attribute_type_validation = super().validate()
+        if self.verifyConfigMediaType(self.Config) and self.verifyImageLayerMediaType(self.Layers):
+           return attribute_type_validation
+        else:
+            return False


### PR DESCRIPTION
**PLEASE DO NOT MERGE THIS**
Hi 😃 !

As defined in [here](https://github.com/opencontainers/image-spec/blob/master/manifest.md), `config` and `layers` needs to validate the `MediaType` on the `Descriptor`.

Something like this could also be true for annotations, index, etc.

I know the repo is still WIP but I would like to point out this situation with the current suggestion.

Implementing something like this could easily allow the inclusion of more artifacts (specs) like `helm`, `Singularity` or `cnab` on a future `contribs` module. This basic validation could also help any future projects working on implement a `distribution` registry.

Signed-off-by: Sergio Morales <sergio@cornershopapp.com>