### PR TITLE
Do not set basic auth if no username/password provided

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate black
-          pip install black==21.6b0
+          pip install black
           black --check opencontainers
 
   testing:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 Versions here coincide with releases on pypi.
 
 ## [master](https://github.com/vsoch/oci-python)
+ - do not set basic auth if no username/password provided (0.0.14)
  - allow for update of a structure attribute, if applicable (0.0.13)
  - fix to bug with parsing www-Authenticate (0.0.12)
  - adding distribution spec (0.0.11)

--- a/opencontainers/distribution/reggie/client.py
+++ b/opencontainers/distribution/reggie/client.py
@@ -222,8 +222,11 @@ class NewClient:
             .SetQueryParam("service", h.Service)
             .SetHeader("Accept", "application/json")
             .SetHeader("User-Agent", self.Config.UserAgent)
-            .SetBasicAuth(self.Config.Username, self.Config.Password)
         )
+
+        # Do not set basic auth if no username/password provided
+        if self.Config.Username and self.Config.Password:
+            req = req.SetBasicAuth(self.Config.Username, self.Config.Password)
 
         # Set the scope, first priority to config, then header
         if self.Config.AuthScope:

--- a/opencontainers/version.py
+++ b/opencontainers/version.py
@@ -4,7 +4,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "opencontainers"


### PR DESCRIPTION
Not able to perform an anonymous request against Docker Hub if no username and password provided when setting up a client