### PR TITLE
feat: support setting proxy for reggie client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 Versions here coincide with releases on pypi.
 
 ## [master](https://github.com/vsoch/oci-python)
+ - support setting proxy for reggie client (0.0.15)
  - do not set basic auth if no username/password provided (0.0.14)
  - allow for update of a structure attribute, if applicable (0.0.13)
  - fix to bug with parsing www-Authenticate (0.0.12)

--- a/opencontainers/distribution/reggie/__init__.py
+++ b/opencontainers/distribution/reggie/__init__.py
@@ -7,6 +7,7 @@ from .client import (
     WithDefaultName,
     WithDebug,
     WithUserAgent,
+    WithProxy,
 )
 from .request import (
     WithName,

--- a/opencontainers/distribution/reggie/client.py
+++ b/opencontainers/distribution/reggie/client.py
@@ -34,6 +34,7 @@ class ClientConfig(BaseConfig):
         "WithDebug",
         "WithDefaultName",
         "WithAuthScope",
+        "WithProxy",
     ]
 
     def __init__(self, address, opts=None):
@@ -48,6 +49,7 @@ class ClientConfig(BaseConfig):
         self.DefaultName = None
         self.UserAgent = DEFAULT_USER_AGENT
         self.required = [self.Address, self.UserAgent]
+        self.Proxy = None
         super().__init__()
 
     def _validate(self):
@@ -118,6 +120,17 @@ def WithUserAgent(userAgent):
     return WithUserAgent
 
 
+def WithProxy(proxy):
+    """
+    WithProxy sets the proxy configuration setting.
+    """
+
+    def WithProxy(config):
+        config.Proxy = proxy
+
+    return WithProxy
+
+
 # Client
 
 
@@ -178,6 +191,8 @@ class NewClient:
         requestClient.SetUrl(url)
         requestClient.SetHeader("User-Agent", self.Config.UserAgent)
         requestClient.SetRetryCallback(rc.RetryCallback)
+        if self.Config.Proxy:
+            requestClient.SetProxy(self.Config.Proxy)
 
         # Return the Client, which has Request and retryCallback
         return requestClient

--- a/opencontainers/distribution/reggie/request.py
+++ b/opencontainers/distribution/reggie/request.py
@@ -35,6 +35,7 @@ class RequestConfig(BaseConfig):
         "WithDigest",
         "WithSessionID",
         "WithRetryCallback",
+        "WithProxy",
     ]
 
     def __init__(self, opts):
@@ -46,6 +47,7 @@ class RequestConfig(BaseConfig):
         self.Digest = None
         self.SessionID = None
         self.RetryCallback = None
+        self.Proxy = None
         self.required = [self.Name]
         super().__init__(opts or [])
 
@@ -106,6 +108,17 @@ def WithRetryCallback(retryCallback):
         config.RetryCallback = retryCallback
 
     return WithRetryCallback
+
+
+def WithProxy(proxy):
+    """
+    WithProxy sets the proxy configuration setting for requests.
+    """
+
+    def WithProxy(config):
+        config.Proxy = proxy
+
+    return WithProxy
 
 
 class RequestClient(requests.Session):
@@ -243,6 +256,18 @@ class RequestClient(requests.Session):
         auth_str = "%s:%s" % (username, password)
         auth_header = base64.b64encode(auth_str.encode("utf-8"))
         return self.SetHeader("Authorization", "Basic %s" % auth_header.decode("utf-8"))
+
+    def SetProxy(self, proxy):
+        """
+        SetProxy sets the proxy configuration setting for requests.
+        """
+        self.proxies.update(
+            {
+                "http": proxy,
+                "https": proxy,
+            }
+        )
+        return self
 
     def Execute(self, method=None, url=None):
         """

--- a/opencontainers/tests/test_distribution.py
+++ b/opencontainers/tests/test_distribution.py
@@ -11,6 +11,8 @@ from opencontainers.distribution.reggie import *
 import os
 import re
 import pytest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 
 # Use the same port across tests
@@ -19,11 +21,51 @@ mock_server = None
 mock_server_thread = None
 
 
+# Simple HTTP proxy server for testing proxy functionality
+class SimpleProxyHandler(BaseHTTPRequestHandler):
+    """A simple HTTP proxy handler that logs requests"""
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"Request proxied successfully")
+        print(f"Proxy handled request: {self.path}")
+
+    def do_PUT(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"Request proxied successfully")
+        print(f"Proxy handled PUT request: {self.path}")
+
+    def log_message(self, format, *args):
+        # Customize logging to show it's from the proxy
+        print(f"PROXY LOG: {format % args}")
+
+
+# Global variables for proxy server
+proxy_port = get_free_port()
+proxy_server = None
+proxy_server_thread = None
+
+
 def setup_module(module):
     """setup any state specific to the execution of the given module."""
     global mock_server
     global mock_server_thread
+    global proxy_server
+    global proxy_server_thread
+
+    # Start the mock registry server
     mock_server, mock_server_thread = start_mock_server(port)
+
+    # Start the proxy server
+    proxy_server = HTTPServer(("localhost", proxy_port), SimpleProxyHandler)
+    proxy_server_thread = Thread(target=proxy_server.serve_forever)
+    proxy_server_thread.setDaemon(True)
+    proxy_server_thread.start()
+    print(f"Proxy server started on port {proxy_port}")
 
 
 def teardown_module(module):
@@ -31,6 +73,7 @@ def teardown_module(module):
     method.
     """
     mock_server.server_close()
+    proxy_server.server_close()
 
 
 def test_distribution_mock_server(tmp_path):
@@ -46,6 +89,24 @@ def test_distribution_mock_server(tmp_path):
         WithUserAgent("reggie-tests"),
     )
     assert not client.Config.Debug
+
+    print("Testing creation of client with proxy")
+    proxy_url = f"http://localhost:{proxy_port}"
+    proxy_client = NewClient(
+        mock_url,
+        WithUsernamePassword("testuser", "testpass"),
+        WithDefaultName("testname"),
+        WithUserAgent("reggie-tests"),
+        WithProxy(proxy_url),
+    )
+    assert proxy_client.Config.Proxy == proxy_url
+
+    # Make a request with the proxy client
+    req = proxy_client.NewRequest("GET", "/v2/<n>/tags/list")
+    response = proxy_client.Do(req)
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
 
     print("Testing setting debug option")
     clientDebug = NewClient(mock_url, WithDebug(True))
@@ -189,6 +250,27 @@ def test_distribution_mock_server(tmp_path):
     print("Check that the body did not get lost somewhere")
     assert req.body == "abc"
 
+    print("Test proxy request with different configuration")
+    # Create a client with a different proxy configuration
+    alt_proxy_url = f"http://localhost:{proxy_port}/alternate"
+    alt_proxy_client = NewClient(
+        mock_url,
+        WithProxy(alt_proxy_url),
+    )
+    assert alt_proxy_client.Config.Proxy == alt_proxy_url
+
+    # Verify that proxy setting is correctly passed to the request
+    proxy_req = alt_proxy_client.NewRequest("GET", "/v2/test/tags/list")
+    assert (
+        proxy_req.proxies
+    ), "Request should have non-empty proxies dictionary when proxy is set"
+    assert (
+        proxy_req.proxies.get("http") == alt_proxy_url
+    ), "HTTP proxy not correctly set"
+    assert (
+        proxy_req.proxies.get("https") == alt_proxy_url
+    ), "HTTPS proxy not correctly set"
+
     print("Test that the retry callback is invoked, if configured.")
     newBody = "not the original body"
 
@@ -214,3 +296,12 @@ def test_distribution_mock_server(tmp_path):
         )
     except Exception as exc:
         assert "ruhroh" in str(exc)
+
+    print("Test proxy setting in request client")
+    # Directly test the SetProxy method on the request client
+    req = client.NewRequest("GET", "/test/endpoint")
+    proxy_addr = f"http://localhost:{proxy_port}/direct-test"
+    req.SetProxy(proxy_addr)
+    # Verify that the proxy is set in the underlying request object when it's executed
+    response = client.Do(req)
+    assert response.status_code == 200, "Request through proxy should succeed"

--- a/opencontainers/version.py
+++ b/opencontainers/version.py
@@ -4,7 +4,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "opencontainers"


### PR DESCRIPTION
Changes
This PR adds test cases for HTTP proxy functionality in the OCI reggie client with basic test.
